### PR TITLE
Fix blank page when the pipeline contains a nil pointer step

### DIFF
--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -60,6 +60,7 @@
 <section class="in-building">
     <ul class="clr-timeline timeline">
         {{ range $pipeStep := .Pipeline.Spec.Steps }}
+            {{ if $pipeStep.Stage }}
             <li class="clr-timeline-step">
                 {{- if $pipeStep.Stage.CompletedTimestamp }}
                     <div class="clr-timeline-step-header">{{ $pipeStep.Stage.CompletedTimestamp.Format "15:04:05" }}</div>
@@ -81,6 +82,7 @@
                     <span class="clr-timeline-step-title">{{ $pipeStep.Stage.Name }}</span>
                 </div>
             </li>
+            {{ end }}
         {{ end }}
     </ul>
 </section>


### PR DESCRIPTION
When a pipeline is finished, we have sometime in the `.Pipeline.Spec.Steps` some stage that are `nil` pointer.
I just add a check in the UI to see if the stage exist.

We have to investigate in the `jenkinsv1.PipelineActivity` to see why.

![](https://media.giphy.com/media/QwwsH661SVEmk/giphy.gif)